### PR TITLE
add released

### DIFF
--- a/.github/workflows/cd-master.yml
+++ b/.github/workflows/cd-master.yml
@@ -2,7 +2,7 @@ name: Master CD Pipeline
 
 on:
   release:
-    types: [published]
+    types: [published,released]
 
 jobs:
   master_publish_to_nmpjs:


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated the GitHub Actions workflow configuration to include the `released` type in the release trigger. This ensures that the workflow is triggered on both `published` and `released` events.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cd-master.yml</strong><dd><code>Update GitHub Actions workflow to include `released` type</code></dd></summary>
<hr>

.github/workflows/cd-master.yml
<li>Added <code>released</code> type to the release trigger in the GitHub Actions <br>workflow.<br>


</details>
    

  </td>
  <td><a href="https://github.com/amna0125/usermaven-js/pull/9/files#diff-a675463abc665069bf0f62a1cfe1ed74d8a312e4d52a176b247ea69b03c22ade">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

