### PR TITLE
run on merged

### DIFF
--- a/.github/workflows/master-release.yml
+++ b/.github/workflows/master-release.yml
@@ -1,14 +1,19 @@
 name: Master Release
 
 on:
-  push:
+  pull_request:
+    types: [ closed ]
     branches:
-      - master
+      - master    
+# on:
+#   push:
+#     branches:
+#       - master
 
 jobs:
     release_on_merge:
         runs-on: ubuntu-latest
-        #if: github.event.pull_request.merged == true
+        if: github.event.pull_request.merged == true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:


### PR DESCRIPTION
### **PR Type**
configuration changes


___

### **Description**
- Updated GitHub Actions workflow to trigger on `pull_request` event instead of `push` for the `master` branch.
- Added condition to ensure the action runs only when the pull request is merged.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>master-release.yml</strong><dd><code>Update GitHub Actions workflow to trigger on pull request merge</code></dd></summary>
<hr>

.github/workflows/master-release.yml
<li>Changed trigger from <code>push</code> to <code>pull_request</code> for <code>master</code> branch.<br> <li> Added condition to check if pull request is merged.<br>


</details>
    

  </td>
  <td><a href="https://github.com/amna0125/usermaven-js/pull/10/files#diff-affcff44476cbd498c18599b88309606d4670e1b6bd50c22efb39078d66f8261">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

