### PR TITLE
adding npm-js-publish

### DIFF
--- a/.github/workflows/cd-master.yml
+++ b/.github/workflows/cd-master.yml
@@ -2,7 +2,7 @@ name: Master CD Pipeline
 
 on:
   release:
-    types: [published,released,created]
+    types: [published]
 
 jobs:
   master_publish_to_nmpjs:
@@ -39,3 +39,16 @@ jobs:
             cd - > /dev/null
         fi
         done
+
+    - name: Publish each package
+      run: |
+        for package in packages/*; do
+          if [ -d "$package" ]; then
+            echo "Publishing $package"
+            cd $package
+            yarn publish --non-interactive --access public
+            cd - > /dev/null
+          fi
+        done
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}        


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Modified the release trigger types in the CD pipeline to only include `published`.
- Added a new step in the CD pipeline to publish each package using `yarn publish`.
- Included the `NODE_AUTH_TOKEN` environment variable for authentication during the publish step.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cd-master.yml</strong><dd><code>Enhance CD pipeline to publish packages with yarn</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/cd-master.yml
<li>Modified the release trigger types to only include <code>published</code>.<br> <li> Added a new step to publish each package using <code>yarn publish</code>.<br> <li> Included environment variable <code>NODE_AUTH_TOKEN</code> for authentication.<br>


</details>
    

  </td>
  <td><a href="https://github.com/amna0125/usermaven-js/pull/17/files#diff-a675463abc665069bf0f62a1cfe1ed74d8a312e4d52a176b247ea69b03c22ade">+15/-2</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

